### PR TITLE
fix: don't freeze event handler

### DIFF
--- a/docs/gatsby-browser.js
+++ b/docs/gatsby-browser.js
@@ -5,3 +5,7 @@
  */
 
 import './src/styles/index.scss'
+
+import LogRocket from 'logrocket'
+
+LogRocket.init('yl40qh/wheel-gestures-dev')

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,6 +34,7 @@
     "gatsby-plugin-typescript": "^2.4.15",
     "gatsby-source-filesystem": "^2.3.24",
     "gatsby-transformer-sharp": "^2.5.13",
+    "logrocket": "^1.0.13",
     "node-sass": "^4.14.1",
     "prism-themes": "^1.4.0",
     "prismjs": "^1.21.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -9456,6 +9456,11 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
 
+logrocket@^1.0.13:
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/logrocket/-/logrocket-1.0.13.tgz#5977f8df794f850b7d0ea5c374f397c8ec2553fd"
+  integrity sha512-zaXdPuVa3Eamw5MZ3R4DtESJulxDZr/2asE+pEChJ8L7gDc8H+zehLZF9b8tS33jMqaNztxXbZY9KWkVm5+Z6g==
+
 longest-streak@^2.0.1:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=10"
   },
   "scripts": {
-    "start": "tsdx watch",
+    "start": "tsdx watch --noClean",
     "build": "tsdx build",
     "test": "tsdx test",
     "lint": "tsdx lint",

--- a/src/events/EventBus.ts
+++ b/src/events/EventBus.ts
@@ -1,3 +1,5 @@
+import { deepFreeze } from '../utils'
+
 export type EventMapEmpty = Record<string, unknown>
 export type EventListener<D = unknown> = (data: D) => void
 export type Off = () => void
@@ -19,7 +21,7 @@ export default function EventBus<EventMap = EventMapEmpty>() {
     listeners[type].forEach((l) => l(data))
   }
 
-  return Object.freeze({
+  return deepFreeze({
     on,
     off,
     dispatch,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -24,7 +24,7 @@ export function absMax(numbers: number[]) {
 export function deepFreeze<T extends object>(o: T): Readonly<T> {
   Object.freeze(o)
   Object.values(o).forEach((value) => {
-    if (value !== null && (typeof value === 'object' || typeof value === 'function') && !Object.isFrozen(value)) {
+    if (value !== null && typeof value === 'object' && !Object.isFrozen(value)) {
       deepFreeze(value)
     }
   })


### PR DESCRIPTION
Even logrocket shouldn't to mutate objects / functions they don't own, this accommodates this for now.
There should not be any negative impact.

fixes #372