### PR TITLE
fix: Update engine to support Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "src"
   ],
   "engines": {
-    "node": "18.x"
+    "node": ">=18"
   },
   "scripts": {
     "start": "tsdx watch --noClean",


### PR DESCRIPTION
`wheel-gestures@2.2.46: The engine "node" is incompatible with this module. Expected version "18.x". Got "20.12.2"`
This will ensure we can use Node 20
Address issue: https://github.com/xiel/wheel-gestures/issues/714